### PR TITLE
Fix high CPU usage with xdotool window title

### DIFF
--- a/.i3blocks.conf
+++ b/.i3blocks.conf
@@ -7,8 +7,8 @@ separator=false
 separator_block_width=8
 
 [focused window]
-command=xdotool getactivewindow getwindowname
-interval=repeat
+command=xtitle -s
+interval=persist
 separator=false
 color=#9fbc00
 


### PR DESCRIPTION
If I have my config set like you have it, i3bar would use ~30% CPU. Installing `xtitle` and changing the config to this keeps i3bar at <0.1%.

Another plus with doing it this way: if there is no window selected, it will be blank!